### PR TITLE
Update micromatch to latest version

### DIFF
--- a/package.json
+++ b/package.json
@@ -36,7 +36,7 @@
     "test": "istanbul cover _mocha && cat ./coverage/lcov.info | coveralls"
   },
   "dependencies": {
-    "micromatch": "^3.1.4",
+    "micromatch": "^3.1.10",
     "normalize-path": "^2.1.1"
   },
   "devDependencies": {


### PR DESCRIPTION
NPM package `braces` lower than 2.3.1 contains vulnerabilities. This has been upgraded and fixed in current version of micromatch so bringing package up to date to remove these vulnerabilities.

![image](https://user-images.githubusercontent.com/5485364/53087901-29dafb80-3500-11e9-8d8f-91ce8b201279.png)


