### PR TITLE
Fix package name typo in README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -11,7 +11,7 @@ __Note: This module has Bash-parity, please be aware that Windows-style backslas
 Usage
 -----
 ```sh
-npm install anymatchx
+npm install anymatch
 ```
 
 #### anymatch(matchers, testString, [returnIndex])


### PR DESCRIPTION
`anymatchx` => `anymatch`