### PR TITLE
export matcher and tester for 3rd party library

### DIFF
--- a/index.d.ts
+++ b/index.d.ts
@@ -15,4 +15,7 @@ declare const anymatch: {
   (matchers: AnymatchMatcher, testString: string|any[], returnIndex: true): number;
   (matchers: AnymatchMatcher, testString: string|any[]): boolean;
 }
-export = anymatch
+
+export {AnymatchMatcher as Matcher}
+export {AnymatchTester as Tester}
+export default anymatch


### PR DESCRIPTION
for 3rd party library like webpack to use anymatch's typesystem, AnymatchMatcher and AnymatchTester needs to be exported, too.

code excerpt from webpack
```
import * as anymatch from 'anymatch';

....
    namespace ICompiler {
        interface WatchOptions {
            ignored?: anymatch.Matcher;
        }
    }
```

https://github.com/DefinitelyTyped/DefinitelyTyped/blob/05e9b741608ddcae39cd8cf473c32b76d5feb49d/types/webpack/index.d.ts#L29

https://github.com/DefinitelyTyped/DefinitelyTyped/blob/05e9b741608ddcae39cd8cf473c32b76d5feb49d/types/webpack/index.d.ts#L1045
