### PR TITLE
allow to specify picomatch options

### DIFF
--- a/README.md
+++ b/README.md
@@ -14,7 +14,7 @@ Usage
 npm install anymatch
 ```
 
-#### anymatch(matchers, testString, [returnIndex])
+#### anymatch(matchers, testString, [returnIndex], [options])
 * __matchers__: (_Array|String|RegExp|Function_)
 String to be directly matched, string with glob patterns, regular expression
 test, function that takes the testString as an argument and returns a truthy
@@ -26,6 +26,7 @@ as the arguments for function matchers.
 * __returnIndex__: (_Boolean [optional]_) If true, return the array index of
 the first matcher that that testString matched, or -1 if no match, instead of a
 boolean result.
+* __options__: (_Object_ [optional]_) Any of the [picomatch](https://github.com/micromatch/picomatch#options) options.
 
 ```js
 const anymatch = require('anymatch');

--- a/index.js
+++ b/index.js
@@ -15,14 +15,15 @@ const arrify = (item) => Array.isArray(item) ? item : [item];
 
 /**
  * @param {AnymatchPattern} matcher
+ * @param {object} options
  * @returns {AnymatchFn}
  */
-const createPattern = (matcher) => {
+const createPattern = (matcher, options) => {
   if (typeof matcher === 'function') {
     return matcher;
   }
   if (typeof matcher === 'string') {
-    const glob = picomatch(matcher);
+    const glob = picomatch(matcher, options);
     return (string) => matcher === string || glob(string);
   }
   if (matcher instanceof RegExp) {
@@ -62,9 +63,10 @@ const matchPatterns = (patterns, negatedGlobs, path, returnIndex) => {
  * @param {AnymatchMatcher} matchers
  * @param {Array|string} testString
  * @param {boolean=} returnIndex
+ * @param {object} options
  * @returns {boolean|number|Function}
  */
-const anymatch = (matchers, testString, returnIndex = false) => {
+const anymatch = (matchers, testString, returnIndex = false, options = undefined) => {
   if (matchers == null) {
     throw new TypeError('anymatch: specify first argument');
   }
@@ -73,8 +75,8 @@ const anymatch = (matchers, testString, returnIndex = false) => {
   const negatedGlobs = mtchers
     .filter(item => typeof item === 'string' && item.charAt(0) === BANG)
     .map(item => item.slice(1))
-    .map(item => picomatch(item));
-  const patterns = mtchers.map(createPattern);
+    .map(item => picomatch(item, options));
+  const patterns = mtchers.map(matcher => createPattern(matcher, options));
 
   if (testString == null) {
     return (testString, ri = false) => {

--- a/test.js
+++ b/test.js
@@ -97,7 +97,7 @@ describe('anymatch', () => {
       assert.throws(() => anymatch());
     })
     it('should not allow bad testString', () => {
-      assert.throws(() => anymatch(matchers, {path: 'path/to/bar.js'}));
+      assert.throws(() => anymatch(matchers, { path: 'path/to/bar.js' }));
     });
     it('should allow string to be passed as first member of an array', () => {
       assert.doesNotThrow(() => anymatch(matchers, ['path/to/bar.js']));
@@ -181,6 +181,13 @@ describe('anymatch', () => {
       assert(anymatch(matchers)('path/to/file.js'));
       assert(!anymatch(matchers, 'path/no/no.js'));
       assert(!anymatch(matchers)('path/no/no.js'));
+    });
+  });
+
+  describe('picomatch options', () => {
+    it('should support picomatch options', () => {
+      assert.equal(false, anymatch('path/to/?dotfile', 'path/to/.dotfile'));
+      assert.equal(true, anymatch('path/to/?dotfile', 'path/to/.dotfile', false, { dot: true }));
     });
   });
 });


### PR DESCRIPTION
This allows to specify options for matching. I think this fixes https://github.com/micromatch/anymatch/issues/33 and it will help for https://github.com/paulmillr/chokidar/issues/870. 