### PR TITLE
fix: do not create pattern from negated matchers

### DIFF
--- a/index.js
+++ b/index.js
@@ -86,7 +86,9 @@ const anymatch = (matchers, testString, options = DEFAULT_OPTIONS) => {
     .filter(item => typeof item === 'string' && item.charAt(0) === BANG)
     .map(item => item.slice(1))
     .map(item => picomatch(item, opts));
-  const patterns = mtchers.map(matcher => createPattern(matcher, opts));
+  const patterns = mtchers
+    .filter(item => typeof item !== 'string' || (typeof item === 'string' && item.charAt(0) !== BANG))
+    .map(matcher => createPattern(matcher, opts));
 
   if (testString == null) {
     return (testString, ri = false) => {

--- a/test.js
+++ b/test.js
@@ -130,7 +130,7 @@ describe('anymatch', () => {
   });
 
   describe('glob negation', () => {
-    after(matchers.splice.bind(matchers, 4, 2));
+    after(matchers.splice.bind(matchers, 4, 3));
 
     it('should respect negated globs included in a matcher array', () => {
       assert(anymatch(matchers, 'path/anyjs/no/no.js'), 'matches existing glob');
@@ -149,6 +149,12 @@ describe('anymatch', () => {
       matchers.push('!path/to/bar.*');
       assert(!anymatch(matchers, 'path/to/bar.js'));
     });
+    it('should not match negated matchers if positive matchers do not match', () => {
+      assert(!anymatch(matchers, 'path/anyjs/no/no.ts'), 'does not match existing glob');
+      matchers.push('!path/anyjs/ts/*.js');
+      assert(!anymatch(matchers, 'path/anyjs/no/no.ts'), 'should not be negated');
+      assert(!anymatch(matchers)('path/anyjs/no/no.ts'), 'should not be negated (curried)');
+    })
   });
 
   describe('windows paths', () => {


### PR DESCRIPTION
Fixes #36.

Negated matchers are already handled separately.