### PR TITLE
Update Typescript Declarations index.d.ts

### DIFF
--- a/index.d.ts
+++ b/index.d.ts
@@ -1,3 +1,5 @@
+import {PicomatchOptions} from "picomatch";
+
 type AnymatchFn = (testString: string) => boolean;
 type AnymatchPattern = string|RegExp|AnymatchFn;
 type AnymatchMatcher = AnymatchPattern|AnymatchPattern[]
@@ -5,13 +7,14 @@ type AnymatchTester = {
   (testString: string|any[], returnIndex: true): number;
   (testString: string|any[]): boolean;
 }
-
-type PicomatchOptions = {dot: boolean};
+type AnymatchOptions = {returnIndex?: boolean} & PicomatchOptions
 
 declare const anymatch: {
   (matchers: AnymatchMatcher): AnymatchTester;
-  (matchers: AnymatchMatcher, testString: null, returnIndex: true | PicomatchOptions): AnymatchTester;
-  (matchers: AnymatchMatcher, testString: string|any[], returnIndex: true | PicomatchOptions): number;
+  (matchers: AnymatchMatcher, testString: null, returnIndex: true | AnymatchOptions): AnymatchTester;
+  (matchers: AnymatchMatcher, testString: string|any[], returnIndex: true): number;
+  (matchers: AnymatchMatcher, testString: string|any[], options: {returnIndex: true} & PicomatchOptions): number;
+  (matchers: AnymatchMatcher, testString: string|any[], options: {returnIndex?: false} & PicomatchOptions): boolean;
   (matchers: AnymatchMatcher, testString: string|any[]): boolean;
 }
 

--- a/package.json
+++ b/package.json
@@ -7,6 +7,7 @@
     "index.d.ts"
   ],
   "dependencies": {
+    "@types/picomatch": "^2.3.0",
     "normalize-path": "^3.0.0",
     "picomatch": "^2.0.4"
   },


### PR DESCRIPTION
Details:
1. Add @types/picomatch as dependency, and import {PicomatchOptions} from "picomatch".
2. Add more function signatures to separate different type of return value: when returnIndex=true, the return value is number, otherwise the return value is boolean.

Motivation: 
Old type declarations will raise TS complie error when using `picomatch` options, such as the following code:
```ts
import anymatch from "anymatch"
anymatch(matcher, filename, {basename: true}) // // will get TS2345: Argument of type '{ basename: boolean; }' is not assignable to parameter of type 'true | PicomatchOptions'. Object literal may only specify known properties, and 'basename' does not exist in type 'PicomatchOptions'.
```
With the modifications in this PR, the error is corrected, and the type declaration is matched with what is described in the README.md.