### PR TITLE
fix: Keep trailing slash on paths

### DIFF
--- a/index.js
+++ b/index.js
@@ -47,7 +47,7 @@ const matchPatterns = (patterns, negPatterns, args, returnIndex) => {
     throw new TypeError('anymatch: second argument must be a string: got ' +
       Object.prototype.toString.call(_path))
   }
-  const path = normalizePath(_path);
+  const path = normalizePath(_path, false);
 
   for (let index = 0; index < negPatterns.length; index++) {
     const nglob = negPatterns[index];

--- a/test.js
+++ b/test.js
@@ -39,6 +39,9 @@ describe('anymatch', () => {
     assert.equal(false, anymatch(emptyObj, ''));
     assert.equal(false, anymatch(Infinity, ''));
   });
+  it('should keep trailing separators on paths to match /*/ globs', () => {
+    assert.equal(true, anymatch('path/to/*/', 'path/to/dir/'));
+  });
 
   describe('with returnIndex = true', () => {
     it('should return the array index of first positive matcher', () => {


### PR DESCRIPTION
While trying to replace `glob` with `anymatch` in `glob-stream`, I encountered a problem where the glob `something/*/` didn't match my directories. This was due to a bug with path normalization in `anymatch` that removes the trailing slash on a path, even though it needs to be there to match the glob.

This passes the `stripTrailing` parameter as `false` to normalize-path so it keeps a trailing separator if it exists.

This shouldn't change any previous behavior because previously `/*/` patterns could never match, but now they can when both the glob & the path string both end in a trailing slash.

@paulmillr Please take a look at this change, as I need it asap to keep pushing for gulp 5.